### PR TITLE
[WIP] Fix unit conversions

### DIFF
--- a/docs/midi_files.rst
+++ b/docs/midi_files.rst
@@ -17,7 +17,7 @@ You can open a file with::
 .. note:: Sysex dumps such as patch data are often stored in SYX files
    rather than MIDI files. If you get "MThd not found. Probably not a
    MIDI file" try ``mido.read_syx_file()``. (See :doc:`syx` for more.)
-   
+
 The ``tracks`` attribute is a list of tracks. Each track is a list of
 messages and meta messages, with the ``time`` attribute of each
 messages set to its delta time (in ticks). (See Tempo and Beat
@@ -82,7 +82,7 @@ argument. The file can then be saved by calling the ``save()`` method::
     track.append(Message('program_change', program=12, time=0))
     track.append(Message('note_on', note=64, velocity=64, time=32))
     track.append(Message('note_off', note=64, velocity=127, time=32))
-    
+
     mid.save('new_song.mid')
 
 The ``MidiTrack`` class is a subclass of list, so you can use all the
@@ -181,46 +181,56 @@ The ``time`` attribute is used in several different ways:
   used for absolute time in ticks or seconds
 
 
-Tempo and Beat Resolution
+Tempo and Time Resolution
 -------------------------
 
 .. image:: images/midi_time.svg
 
-Timing in MIDI files is centered around ticks and beats. A beat is the same as 
-a quarter note. Beats are divided into ticks, the smallest unit of time in 
-MIDI.
+Timing in MIDI files is centered around ticks. Each message in a MIDI file has
+a delta time, which tells how many ticks have passed since the last message.
 
-Each message in a MIDI file has a delta time, which tells how many ticks have 
-passed since the last message. The length of a tick is defined in ticks per 
-beat. This value is stored as ``ticks_per_beat`` in MidiFile objects and 
-remains fixed throughout the song.
+A tick is the smallest unit of time in MIDI and remains fixed throughout the
+song. Each quarter notes is divided into a certain number of ticks, often
+referred as the resolution of the file or pulses per quarter note (PPQN). This
+resolution is stored as ``ticks_per_beat`` in MidiFile objects.
 
+The meaning of this ``ticks_per_beat`` in terms of absolute timing depends on
+the tempo and time signature of the file.
 
 MIDI Tempo vs. BPM
 ^^^^^^^^^^^^^^^^^^
 
-Unlike music, tempo in MIDI is not given as beats per minute, but rather in 
-microseconds per beat.
+Unlike music, tempo in MIDI is not given as beats per minute (BPM), but rather
+in microseconds per quarter note, with a default tempo of 500000 microseconds
+per quarter note. Given a default 4/4 time signature where a beat is exactly a
+quarter note, this corresponds to 120 beats per minute.
 
-The default tempo is 500000 microseconds per beat, which is 120 beats per 
-minute. The meta message 'set_tempo' can be used to change tempo during a song.
+In case of different time signatures, the length of a beat depends on the
+denominator of the time signature. E.g. in 2/2 time signature a beat has a
+length of a half note, i.e. two quarter notes. Thus the default MIDI tempo of
+500000 corresponds to a beat length of 1 second which is 60 BPM.
 
-You can use :py:func:`bpm2tempo` and :py:func:`tempo2bpm` to convert to and 
-from beats per minute. Note that :py:func:`tempo2bpm` may return a floating 
+The meta messages 'set_tempo' and 'time_signature' can be used to change
+the tempo and time signature during a song, respectively.
+
+You can use :py:func:`bpm2tempo` and :py:func:`tempo2bpm` to convert to and
+from beats per minute. Note that :py:func:`tempo2bpm` may return a floating
 point number.
 
 Converting Between Ticks and Seconds
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To convert from MIDI time to absolute time in seconds, the number of beats per 
-minute (BPM) and ticks per beat (often called pulses per quarter note or PPQ, 
-for short) have to be decided upon.
+To convert from MIDI time to absolute time in seconds, the tempo (either
+in number of beats per minute (BPM) or microseconds per quarter note, see
+`MIDI Tempo vs. BPM`_ above) and ticks per per quarter note have to be decided
+upon.
 
 You can use :py:func:`tick2second` and :py:func:`second2tick` to convert to
-and from seconds and ticks. Note that integer rounding of the result might be 
+and from seconds and ticks. Note that integer rounding of the result might be
 necessary because MIDI files require ticks to be integers.
 
-If you have a lot of rounding errors you should increase the time resolution 
-with more ticks per beat, by setting MidiFile.ticks_per_beat to a large number.
-Typical values range from 96 to 480 but some use even more ticks per beat.
+If you have a lot of rounding errors you should increase the time resolution
+with more ticks per quarter note, by setting MidiFile.ticks_per_beat to a
+large number. Typical values range from 96 to 480 but some use even more ticks
+per quarter note.
 

--- a/mido/midifiles/units.py
+++ b/mido/midifiles/units.py
@@ -20,27 +20,23 @@ def second2tick(second, ticks_per_beat, tempo):
     return second / scale
 
 
-def bpm2tempo(bpm):
-    """Convert beats per minute to MIDI file tempo.
+def bpm2tempo(bpm, time_signature=(4, 4)):
+    """Convert BPM (beats per minute) to MIDI file tempo (microseconds per
+    quarter note).
 
-    Returns microseconds per beat as an integer::
-
-        240 => 250000
-        120 => 500000
-        60 => 1000000
+    Depending on the chosen time signature a bar contains a different number of
+    beats. These beats are multiples/fractions of a quarter note, thus the
+    returned BPM depend on the time signature.
     """
-    # One minute is 60 million microseconds.
-    return int(round((60 * 1000000) / bpm))
+    return int(round(60 * 1e6 / bpm * time_signature[1] / 4.))
 
 
-def tempo2bpm(tempo):
-    """Convert MIDI file tempo to BPM.
+def tempo2bpm(tempo, time_signature=(4, 4)):
+    """Convert MIDI file tempo (microseconds per quarter note) to BPM (beats
+    per minute).
 
-    Returns BPM as an integer or float::
-
-        250000 => 240
-        500000 => 120
-        1000000 => 60
+    Depending on the chosen time signature a bar contains a different number of
+    beats. These beats are multiples/fractions of a quarter note, thus the
+    returned tempo depends on the time signature.
     """
-    # One minute is 60 million microseconds.
-    return (60 * 1000000) / tempo
+    return 60 * 1e6 / tempo * time_signature[1] / 4.

--- a/mido/midifiles/units.py
+++ b/mido/midifiles/units.py
@@ -1,9 +1,9 @@
 def tick2second(tick, ticks_per_beat, tempo):
     """Convert absolute time in ticks to seconds.
 
-    Returns absolute time in seconds for a chosen MIDI file time
-    resolution (ticks per beat, also called PPQN or pulses per quarter
-    note) and tempo (microseconds per beat).
+    Returns absolute time in seconds for a chosen MIDI file time resolution
+    (ticks/pulses per quarter note, also called PPQN) and tempo (microseconds
+    per quarter note).
     """
     scale = tempo * 1e-6 / ticks_per_beat
     return tick * scale
@@ -12,9 +12,9 @@ def tick2second(tick, ticks_per_beat, tempo):
 def second2tick(second, ticks_per_beat, tempo):
     """Convert absolute time in seconds to ticks.
 
-    Returns absolute time in ticks for a chosen MIDI file time
-    resolution (ticks per beat, also called PPQN or pulses per quarter
-    note) and tempo (microseconds per beat).
+    Returns absolute time in ticks for a chosen MIDI file time resolution
+    (ticks/pulses per quarter note, also called PPQN) and tempo (microseconds
+    per quarter note). Normal rounding applies.
     """
     scale = tempo * 1e-6 / ticks_per_beat
     return int(round(second / scale))
@@ -26,7 +26,7 @@ def bpm2tempo(bpm, time_signature=(4, 4)):
 
     Depending on the chosen time signature a bar contains a different number of
     beats. These beats are multiples/fractions of a quarter note, thus the
-    returned BPM depend on the time signature.
+    returned BPM depend on the time signature. Normal rounding applies.
     """
     return int(round(60 * 1e6 / bpm * time_signature[1] / 4.))
 

--- a/mido/midifiles/units.py
+++ b/mido/midifiles/units.py
@@ -17,7 +17,7 @@ def second2tick(second, ticks_per_beat, tempo):
     note) and tempo (microseconds per beat).
     """
     scale = tempo * 1e-6 / ticks_per_beat
-    return second / scale
+    return int(round(second / scale))
 
 
 def bpm2tempo(bpm, time_signature=(4, 4)):

--- a/tests/midifiles/test_units.py
+++ b/tests/midifiles/test_units.py
@@ -52,10 +52,17 @@ def test_bpm2tempo():
 # TODO: these tests could be improved with better test values such as
 # edge cases.
 def test_tick2second():
+    # default tempo (500000 ms per quarter note)
     assert tick2second(1, ticks_per_beat=100, tempo=500000) == 0.005
     assert tick2second(2, ticks_per_beat=100, tempo=100000) == 0.002
 
 
 def test_second2tick():
+    # default tempo (500000 ms per quarter note)
+    assert second2tick(0.001, ticks_per_beat=100, tempo=500000) == 0
+    assert second2tick(0.004, ticks_per_beat=100, tempo=500000) == 1
     assert second2tick(0.005, ticks_per_beat=100, tempo=500000) == 1
-    assert second2tick(0.002, ticks_per_beat=100, tempo=100000) == 2
+    # TODO: Python 2 and 3 rounds differently, find a solution?
+    #       The result produced by Python 3 seems the way to go
+    assert second2tick(0.0015, ticks_per_beat=100, tempo=100000) == 2
+    assert second2tick(0.0025, ticks_per_beat=100, tempo=100000) == 2

--- a/tests/midifiles/test_units.py
+++ b/tests/midifiles/test_units.py
@@ -1,20 +1,56 @@
 from mido.midifiles.units import tempo2bpm, bpm2tempo, tick2second, second2tick
 
 
-def test_tempo2bpm_bpm2tempo():
-    for bpm, tempo in [
-            (20, 3000000),
-            (60, 1000000),
-            (120, 500000),
-            (240, 250000),
-    ]:
-        assert bpm == tempo2bpm(tempo)
-        assert tempo == bpm2tempo(bpm)
+def test_tempo2bpm():
+    # default tempo (500000 ms per quarter note)
+    assert tempo2bpm(500000) == 120
+    assert tempo2bpm(1000000) == 60
+    # x/4 time signature: 4 beats (quarter notes) per bar
+    # 60 bpm: 1 beat / sec = 1 quarter note / sec: 1 sec / quarter note
+    assert bpm2tempo(1000000, time_signature=(4, 4)) == 60
+    # 120 bpm: 2 beat / sec = 2 quarter note / sec: 0.5 sec / quarter note
+    assert bpm2tempo(500000, time_signature=(4, 4)) == 120
+    assert bpm2tempo(500000, time_signature=(3, 4)) == 120  # 3/4 is the same
+    # x/2 time signature: 2 beats (half notes) per bar
+    # 60 bpm: 1 beat / sec = 2 quarter note / sec: 0.5 sec / quarter note
+    assert bpm2tempo(500000, time_signature=(2, 2)) == 60
+    # 120 bpm: 2 beat / sec = 4 quarter note / sec: 0.25 sec / quarter note
+    assert bpm2tempo(250000, time_signature=(2, 2)) == 120
+    assert bpm2tempo(250000, time_signature=(3, 2)) == 120  # 3/2 is the same
+    # x/8 time signature: 8 beats (eighth notes) per bar
+    # 60 bpm: 1 beat / sec = 0.5 quarter note / sec: 2 sec / quarter note
+    assert bpm2tempo(2000000, time_signature=(8, 8)) == 60
+    # 120 bpm: 2 beat / sec = 1 quarter note / sec: 1 sec / quarter note
+    assert bpm2tempo(1000000, time_signature=(8, 8)) == 120
+    assert bpm2tempo(1000000, time_signature=(8, 8)) == 120  # 6/8 is the same
+
+
+def test_bpm2tempo():
+    # default tempo (500000 ms per quarter note)
+    assert bpm2tempo(60) == 1000000
+    assert bpm2tempo(120) == 500000
+    # x/4 time signature: 4 beats (quarter notes) per bar
+    # 60 bpm: 1 beat / sec = 1 quarter note / sec: 1 sec / quarter note
+    assert bpm2tempo(60, time_signature=(4, 4)) == 1000000
+    # 120 bpm: 2 beat / sec = 2 quarter note / sec: 0.5 sec / quarter note
+    assert bpm2tempo(120, time_signature=(4, 4)) == 500000
+    assert bpm2tempo(120, time_signature=(3, 4)) == 500000  # 3/4 is the same
+    # x/2 time signature: 2 beats (half notes) per bar
+    # 60 bpm: 1 beat / sec = 2 quarter note / sec: 0.5 sec / quarter note
+    assert bpm2tempo(60, time_signature=(2, 2)) == 500000
+    # 120 bpm: 2 beat / sec = 4 quarter note / sec: 0.25 sec / quarter note
+    assert bpm2tempo(120, time_signature=(2, 2)) == 250000
+    assert bpm2tempo(120, time_signature=(3, 2)) == 250000  # 3/2 is the same
+    # x/8 time signature: 8 beats (eighth notes) per bar
+    # 60 bpm: 1 beat / sec = 0.5 quarter note / sec: 2 sec / quarter note
+    assert bpm2tempo(60, time_signature=(8, 8)) == 2000000
+    # 120 bpm: 2 beat / sec = 1 quarter note / sec: 1 sec / quarter note
+    assert bpm2tempo(120, time_signature=(8, 8)) == 1000000
+    assert bpm2tempo(120, time_signature=(8, 8)) == 1000000  # 6/8 is the same
 
 
 # TODO: these tests could be improved with better test values such as
 # edge cases.
-
 def test_tick2second():
     assert tick2second(1, ticks_per_beat=100, tempo=500000) == 0.005
     assert tick2second(2, ticks_per_beat=100, tempo=100000) == 0.002


### PR DESCRIPTION
This PR addresses #102 and adds the necessary time signature arguments to the functions in `mido.midifiles.units` and modifies `MidiFile.__iter__` to also respect time signature events in a MIDI stream/file.

This PR furthermore adds a couple of other (related) things:

- add option to `MidiFile` to choose the timing unit to be used (ticks, seconds, beats),
- add option to `MidiFile` to choose between relative and absolute timing when iterating over messages.

Before being able to be merged, these points should be discussed/addressed:

- [ ] Extend the documentation to reflect all introduced changes, especially update the image in `midi_files.rst`.
- [ ] Import the new `tick2beat` and `beat2tick` into the main namespace?
- [ ] Include `tick2beat` and `beat2tick` in the API docs.
- [ ] `MidiFile.length` raises a `ValueError` whereas `MidiFile.__iter__` a `TypeError` in case of type 2 MIDI files. Which one is more appropriate?
- [ ]  Add docstrings, but which docstring format to use?
- [ ] renaming `ticks_per_beat` to `ticks_per_quarter_note` or add new variable (how to deprecate the old one)?